### PR TITLE
Editor actions issue fix

### DIFF
--- a/Project/Assets/LunarConsole/Editor/LunarConsoleActionsEditor.cs
+++ b/Project/Assets/LunarConsole/Editor/LunarConsoleActionsEditor.cs
@@ -165,12 +165,21 @@ namespace LunarConsoleEditorInternal
                             int newIndex = EditorGUILayout.Popup(oldIndex, functions.names);
                             if (oldIndex != newIndex)
                             {
-                                var typeName = functions.componentTypes[newIndex - 2].AssemblyQualifiedName;
-                                var methodName = functions.componentMethods[newIndex - 2].Name;
+                                if (newIndex >= 2)
+                                {
+                                    var typeName = functions.componentTypes[newIndex - 2].AssemblyQualifiedName;
+                                    var methodName = functions.componentMethods[newIndex - 2].Name;
 
-                                componentTypeProperty.stringValue = typeName;
-                                componentMethodProperty.stringValue = methodName;
-                                nameProperty.stringValue = newIndex >= 2 ? StringUtils.ToDisplayName(methodName) : "";
+                                    componentTypeProperty.stringValue = typeName;
+                                    componentMethodProperty.stringValue = methodName;
+                                    nameProperty.stringValue = StringUtils.ToDisplayName(methodName);
+                                }
+                                else
+                                {
+                                    componentTypeProperty.stringValue = null;
+                                    componentMethodProperty.stringValue = null;
+                                    nameProperty.stringValue = "";
+                                }
                             }
                         }
                         EditorGUILayout.EndHorizontal();

--- a/Project/Assets/LunarConsole/Scripts/LunarConsoleActions.cs
+++ b/Project/Assets/LunarConsole/Scripts/LunarConsoleActions.cs
@@ -55,7 +55,19 @@ namespace LunarConsolePluginInternal
 
         public void Register()
         {
-            if (m_name != null && m_componentMethodName != null)
+            if (string.IsNullOrEmpty(m_name))
+            {
+                Log.w("Unable to register action: name is null or empty");
+            }
+            else if (m_target == null)
+            {
+                Log.w("Unable to register action '{0}': target GameObject is missing", m_name);
+            }
+            else if (string.IsNullOrEmpty(m_componentMethodName))
+            {
+                Log.w("Unable to register action '{0}' for '{1}': function is missing", m_name, m_target.name);
+            }
+            else
             {
                 LunarConsole.RegisterAction(m_name, Invoke);
             }

--- a/Project/ProjectSettings/ProjectVersion.txt
+++ b/Project/ProjectSettings/ProjectVersion.txt
@@ -1,1 +1,1 @@
-m_EditorVersion: 5.6.0f3
+m_EditorVersion: 5.6.1f1


### PR DESCRIPTION
Fixed exception while selecting 'No Function':  
![upload_2017-6-24_20-28-47](https://user-images.githubusercontent.com/786644/27568592-869b18f8-5aa7-11e7-8689-22c36c008dab.png)
```
IndexOutOfRangeException: Array index is out of range.
LunarConsoleEditorInternal.LunarConsoleActionsEditor.OnInspectorGUI () (at Assets/LunarConsole/Editor/LunarConsoleActionsEditor.cs:168)
UnityEditor.InspectorWindow.DrawEditor (UnityEditor.Editor[] editors, Int32 editorIndex, Boolean rebuildOptimizedGUIBlock, System.Boolean& showImportedObjectBarNext, UnityEngine.Rect& importedObjectBarRect) (at C:/buildslave/unity/build/Editor/Mono/Inspector/InspectorWindow.cs:1227)
UnityEditor.PopupCallbackInfo:SetEnumValueDelegate(Object, String[], Int32)
```