### PR TITLE
Explicit initialize LunarConsoleSettings

### DIFF
--- a/Project/Assets/LunarConsole/Scripts/LunarConsole.cs
+++ b/Project/Assets/LunarConsole/Scripts/LunarConsole.cs
@@ -94,7 +94,7 @@ namespace LunarConsolePlugin
         #pragma warning disable 0414
 
         [SerializeField]
-        LunarConsoleSettings m_settings;
+        LunarConsoleSettings m_settings = new LunarConsoleSettings();
 
         [Range(128, 65536)]
         [Tooltip("Logs will be trimmed to the capacity")]


### PR DESCRIPTION
I use LunarConsole by code instantiating, not save prefab in scene.
But i got error in real device when instantating LunarConsole

07-07 16:21:18.533 22595 22676 F art     : art/runtime/java_vm_ext.cc:470] JNI DETECTED ERROR IN APPLICATION: JNI NewStringUTF called with pending exception spacemadness.com.lunarconsole.console.EditorSettingsException: Invalid settings json: 
07-07 16:21:18.533 22595 22676 F art     : art/runtime/java_vm_ext.cc:470]   at spacemadness.com.lunarconsole.console.EditorSettings spacemadness.com.lunarconsole.console.EditorSettings.fromJson(java.lang.String) (EditorSettings.java:60)
07-07 16:21:18.533 22595 22676 F art     : art/runtime/java_vm_ext.cc:470]   at void spacemadness.com.lunarconsole.console.ConsolePlugin$UnitySettings.<init>(spacemadness.com.lunarconsole.console.ConsolePluginImp, java.lang.String, int, int, java.lang.String, java.lang.String) (ConsolePlugin.java:137)
07-07 16:21:18.533 22595 22676 F art     : art/runtime/java_vm_ext.cc:470]   at void spacemadness.com.lunarconsole.console.ConsolePlugin.init(java.lang.String, java.lang.String, java.lang.String, int, int, java.lang.String, java.lang.String) (ConsolePlugin.java:323)
07-07 16:21:18.533 22595 22676 F art     : art/runtime/java_vm_ext.cc:470]   at boolean com.unity3d.player.UnityPlayer.nativeRender() ((null):-2)
07-07 16:21:18.533 22595 22676 F art     : art/runtime/java_vm_ext.cc:470]   at boolean com.unity3d.player.UnityPlayer.a(com.unity3d.player.UnityPlayer) ((null):-1)
07-07 16:21:18.533 22595 22676 F art     : art/runtime/java_vm_ext.cc:470]   at boolean com.unity3d.player.UnityPlayer$c$1.handleMessage(android.os.Message) ((null):-1)
07-07 16:21:18.533 22595 22676 F art     : art/runtime/java_vm_ext.cc:470]   at void android.os.Handler.dispatchMessage(android.os.Message) (Handler.java:98)
07-07 16:21:18.533 22595 22676 F art     : art/runtime/java_vm_ext.cc:470]   at void android.os.Looper.loop() (Looper.java:154)
07-07 16:21:18.533 22595 22676 F art     : art/runtime/java_vm_ext.cc:470]   at void com.unity3d.player.UnityPlayer$c.run() ((null):-1)
07-07 16:21:18.533 22595 22676 F art     : art/runtime/java_vm_ext.cc:470] Caused by: org.json.JSONException: End of input at character 0 of 
07-07 16:21:18.533 22595 22676 F art     : art/runtime/java_vm_ext.cc:470]   at org.json.JSONException org.json.JSONTokener.syntaxError(java.lang.String) (JSONTokener.java:449)
07-07 16:21:18.533 22595 22676 F art     : art/runtime/java_vm_ext.cc:470]   at java.lang.Object org.json.JSONTokener.nextValue() (JSONTokener.java:97)
07-07 16:21:18.533 22595 22676 F art     : art/runtime/java_vm_ext.cc:470]   at void org.json.JSONObject.<init>(org.json.JSONTokener) (JSONObject.java:156)
07-07 16:21:18.533 22595 22676 F art     : art/runtime/java_vm_ext.cc:470]   at void org.json.JSONObject.<init>(java.lang.String) (JSONObject.java:173)
07-07 16:21:18.533 22595 22676 F art     : art/runtime/java_vm_ext.cc:470]   at spacemadness.com.lunarconsole.console.EditorSettings spacemadness.com.lunarconsole.console.EditorSettings.fromJson(java.lang.String) (EditorSettings.java:44)
07-07 16:21:18.533 22595 22676 F art     : art/runtime/java_vm_ext.cc:470]   at void spacemadness.com.lunarconsole.console.ConsolePlugin$UnitySettings.<init>(spacemadness.com.lunarconsole.console.ConsolePluginImp, java.lang.String, int, int, java.lang.String, java.lang.String) (ConsolePlugin.java:137)
07-07 16:21:18.533 22595 22676 F art     : art/runtime/java_vm_ext.cc:470]   at void spacemadness.com.lunarconsole.console.ConsolePlugin.init(java.lang.String, java.lang.String, java.lang.String, int, int, java.lang.String, java.lang.String) (ConsolePlugin.java:323)
07-07 16:21:18.533 22595 22676 F art     : art/runtime/java_vm_ext.cc:470]   at boolean com.unity3d.player.UnityPlayer.nativeRender() ((null):-2)
07-07 16:21:18.533 22595 22676 F art     : art/runtime/java_vm_ext.cc:470]   at boolean com.unity3d.player.UnityPlayer.a(com.unity3d.player.UnityPlayer) ((null):-1)
07-07 16:21:18.533 22595 22676 F art     : art/runtime/java_vm_ext.cc:470]   at boolean com.unity3d.player.UnityPlayer$c$1.handleMessage(android.os.Message) ((null):-1)
07-07 16:21:18.533 22595 22676 F art     : art/runtime/java_vm_ext.cc:470]   at void android.os.Handler.dispatchMessage(android.os.Message) (Handler.java:98)
07-07 16:21:18.533 22595 22676 F art     : art/runtime/java_vm_ext.cc:470]   at void android.os.Looper.loop() (Looper.java:154)
07-07 16:21:18.533 22595 22676 F art     : art/runtime/java_vm_ext.cc:470]   at void com.unity3d.player.UnityPlayer$c.run() ((null):-1)
07-07 16:21:18.533 22595 22676 F art     : art/runtime/java_vm_ext.cc:470] 
07-07 16:21:18.533 22595 22676 F art     : art/runtime/java_vm_ext.cc:470]     in call to NewStringUTF
07-07 16:21:18.533 22595 22676 F art     : art/runtime/java_vm_ext.cc:470]     from boolean com.unity3d.player.UnityPlayer.nativeRender()
07-07 16:21:18.533 22595 22676 F art     : art/runtime/java_vm_ext.cc:470] "UnityMain" prio=5 tid=14 Runnable
07-07 16:21:18.533 22595 22676 F art     : art/runtime/java_vm_ext.cc:470]   | group="main" sCount=0 dsCount=0 obj=0x12c4c820 self=0xde272500
07-07 16:21:18.533 22595 22676 F art     : art/runtime/java_vm_ext.cc:470]   | sysTid=22676 nice=0 cgrp=default sched=0/0 handle=0xcda23920
07-07 16:21:18.533 22595 22676 F art     : art/runtime/java_vm_ext.cc:470]   | state=R schedstat=( 0 0 0 ) utm=558 stm=74 core=5 HZ=100
07-07 16:21:18.533 22595 22676 F art     : art/runtime/java_vm_ext.cc:470]   | stack=0xcd921000-0xcd923000 stackSize=1038KB
07-07 16:21:18.533 22595 22676 F art     : art/runtime/java_vm_ext.cc:470]   | held mutexes= "mutator lock"(shared held)
07-07 16:21:18.533 22595 22676 F art     : art/runtime/java_vm_ext.cc:470]   native: #00 pc 00351449  /system/lib/libart.so (_ZN3art15DumpNativeStackERNSt3__113basic_ostreamIcNS0_11char_traitsIcEEEEiP12BacktraceMapPKcPNS_9ArtMethodEPv+128)
07-07 16:21:18.533 22595 22676 F art     : art/runtime/java_vm_ext.cc:470]   native: #01 pc 0033195d  /system/lib/libart.so (_ZNK3art6Thread9DumpStackERNSt3__113basic_ostreamIcNS1_11char_traitsIcEEEEbP12BacktraceMap+304)
07-07 16:21:18.533 22595 22676 F art     : art/runtime/java_vm_ext.cc:470]   native: #02 pc 00239f77  /system/lib/libart.so (_ZN3art9JavaVMExt8JniAbortEPKcS2_+846)
07-07 16:21:18.533 22595 22676 F art     : art/runtime/java_vm_ext.cc:470]   native: #03 pc 0023a4af  /system/lib/libart.so (_ZN3art9JavaVMExt9JniAbortVEPKcS2_St9__va_list+58)
07-07 16:21:18.533 22595 22676 F art     : art/runtime/java_vm_ext.cc:470]   native: #04 pc 000ca813  /system/lib/libart.so (_ZN3art11ScopedCheck6AbortFEPKcz+42)
07-07 16:21:18.533 22595 22676 F art     : art/runtime/java_vm_ext.cc:470]   native: #05 pc 000ca403  /system/lib/libart.so (_ZN3art11ScopedCheck11CheckThreadEP7_JNIEnv+362)
07-07 16:21:18.533 22595 22676 F art     : art/runtime/java_vm_ext.cc:470]   native: #06 pc 000c9417  /system/lib/libart.so (_ZN3art11ScopedCheck22CheckPossibleHeapValueERNS_18ScopedObjectAccessEcNS_12JniValueTypeE+26)
07-07 16:21:18.533 22595 22676 F art     : art/runtime/java_vm_ext.cc:470]   native: #07 pc 000c88e9  /system/lib/libart.so (_ZN3art11ScopedCheck5CheckERNS_18ScopedObjectAccessEbPKcPNS_12JniValueTypeE+800)
07-07 16:21:18.533 22595 22676 F art     : art/runtime/java_vm_ext.cc:470]   native: #08 pc 000c486f  /system/lib/libart.so (_ZN3art8CheckJNI12NewStringUTFEP7_JNIEnvPKc+446)
07-07 16:21:18.533 22595 22676 F art     : art/runtime/java_vm_ext.cc:470]   native: #09 pc 00c62d38  /data/app/com.nhnent.SKQUEST-1/lib/arm/libunity.so (_Z44AndroidJNI_CUSTOM_INTERNAL_CALL_NewStringUTFP10MonoStringRPv+264)
07-07 16:21:18.533 22595 22676 F art     : art/runtime/java_vm_ext.cc:470]   native: #10 pc 0000589c   (???)
07-07 16:21:18.533 22595 22676 F art     : art/runtime/java_vm_ext.cc:470]   at com.unity3d.player.UnityPlayer.nativeRender(Native method)
07-07 16:21:18.533 22595 22676 F art     : art/runtime/java_vm_ext.cc:470]   at com.unity3d.player.UnityPlayer.a(unavailable:-1)
07-07 16:21:18.533 22595 22676 F art     : art/runtime/java_vm_ext.cc:470]   at com.unity3d.player.UnityPlayer$c$1.handleMessage(unavailable:-1)
07-07 16:21:18.533 22595 22676 F art     : art/runtime/java_vm_ext.cc:470]   at android.os.Handler.dispatchMessage(Handler.java:98)
07-07 16:21:18.533 22595 22676 F art     : art/runtime/java_vm_ext.cc:470]   at android.os.Looper.loop(Looper.java:154)
07-07 16:21:18.533 22595 22676 F art     : art/runtime/java_vm_ext.cc:470]   at com.unity3d.player.UnityPlayer$c.run(unavailable:-1)
07-07 16:21:18.533 22595 22676 F art     : art/runtime/java_vm_ext.cc:470] 

It looks like empty string got passed and failed to making JSONObject
Code checks editorsettings is null or not but by the log, the string is empty string not null

[SerializeField] attribute makes unity to initialize LunarConsoleSettings but it is not initialized under code instantiating flow