### PR TITLE
Fixes for exceptions on null checks

### DIFF
--- a/Project/Assets/LunarConsole/Editor/LunarConsoleHttpClient.cs
+++ b/Project/Assets/LunarConsole/Editor/LunarConsoleHttpClient.cs
@@ -82,7 +82,7 @@ namespace LunarConsoleEditorInternal
         {
             if (uri == null)
             {
-                throw new ArgumentNullException("Uri is null");
+                throw new ArgumentNullException("uri");
             }
 
             m_uri = uri;
@@ -93,7 +93,7 @@ namespace LunarConsoleEditorInternal
         {
             if (callback == null)
             {
-                throw new ArgumentNullException("Callback is null");
+                throw new ArgumentNullException("callback");
             }
 
             if (m_client == null)
@@ -129,7 +129,7 @@ namespace LunarConsoleEditorInternal
         {
             if (callback == null)
             {
-                throw new ArgumentNullException("Callback is null");
+                throw new ArgumentNullException("callback");
             }
 
             if (m_client == null)

--- a/Project/Assets/LunarConsole/Editor/Updater.cs
+++ b/Project/Assets/LunarConsole/Editor/Updater.cs
@@ -344,7 +344,7 @@ namespace LunarConsoleEditorInternal
             {
                 if (key == null)
                 {
-                    throw new NullReferenceException("Key is null");
+                    throw new ArgumentNullException("key");
                 }
                 
                 m_key = key;

--- a/Project/Assets/LunarConsole/Scripts/Actions/CAction.cs
+++ b/Project/Assets/LunarConsole/Scripts/Actions/CAction.cs
@@ -51,7 +51,7 @@ namespace LunarConsolePluginInternal
 
             if (actionDelegate == null)
             {
-                throw new ArgumentNullException("Action delegate is null");
+                throw new ArgumentNullException("actionDelegate");
             }
 
             m_id = s_nextActionId++;

--- a/Project/Assets/LunarConsole/Scripts/Actions/CVar.cs
+++ b/Project/Assets/LunarConsole/Scripts/Actions/CVar.cs
@@ -137,7 +137,7 @@ namespace LunarConsolePlugin
         {
             if (name == null)
             {
-                throw new NullReferenceException("Name is null");
+                throw new ArgumentNullException("name");
             }
 
             m_id = ++s_nextId;

--- a/Project/Assets/LunarConsole/Scripts/Utils/Iterator.cs
+++ b/Project/Assets/LunarConsole/Scripts/Utils/Iterator.cs
@@ -40,7 +40,7 @@ namespace LunarConsolePluginInternal
         {
             if (target == null)
             {
-                throw new NullReferenceException("target is null");
+                throw new ArgumentNullException("target");
             }
 
             m_target = target;


### PR DESCRIPTION
NullReferenceException is removed in preference of ArgumentNullException.
Fixed argument for ArgumentNullException constructor to contain argument name only.