### PR TITLE
remove the if statement that is always 'false'

### DIFF
--- a/Native/Android/LunarConsole/lunarConsole/src/main/java/spacemadness/com/lunarconsole/debug/Assert.java
+++ b/Native/Android/LunarConsole/lunarConsole/src/main/java/spacemadness/com/lunarconsole/debug/Assert.java
@@ -2052,10 +2052,7 @@ public class Assert // FIXME: rename methods to assert*
     {
         if (IsEnabled && (collection != null && collection.contains(expected)))
         {
-            if (collection == null)
-                AssertHelper("Assertion failed: collection is null");
-            else
-                AssertHelper("Assertion failed: collection contains the item %s", expected);
+            AssertHelper("Assertion failed: collection contains the item %s", expected);
         }
     }
 


### PR DESCRIPTION
hello, i found a Code Quality Issue for this file that Conditions should not unconditionally evaluate to "TRUE" or to "FALSE".
previous condition `IsEnabled && (collection != null && collection.contains(expected))` ensures the `collection` is not null. so the `collection == null` is always false and the code `AssertHelper("Assertion failed: collection is null");` will never be executed.
[https://rules.sonarsource.com/java/type/Bug/RSPEC-1145](url)