### PR TITLE
Fixed locale-specific decimal points while working with floats

### DIFF
--- a/Native/Android/LunarConsole/lunarConsole/src/main/java/spacemadness/com/lunarconsole/console/DefaultColorFactory.java
+++ b/Native/Android/LunarConsole/lunarConsole/src/main/java/spacemadness/com/lunarconsole/console/DefaultColorFactory.java
@@ -30,8 +30,6 @@ import java.util.Map;
 import spacemadness.com.lunarconsole.R;
 import spacemadness.com.lunarconsole.utils.StringUtils;
 
-import static spacemadness.com.lunarconsole.utils.StringUtils.parseInt;
-
 public class DefaultColorFactory implements ColorFactory {
     private final Context context;
     private final Map<String, Integer> colorLookup;

--- a/Native/Android/LunarConsole/lunarConsole/src/main/java/spacemadness/com/lunarconsole/utils/StringUtils.java
+++ b/Native/Android/LunarConsole/lunarConsole/src/main/java/spacemadness/com/lunarconsole/utils/StringUtils.java
@@ -23,12 +23,17 @@
 package spacemadness.com.lunarconsole.utils;
 
 import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
 import java.text.NumberFormat;
+import java.text.ParseException;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 public class StringUtils {
-    private static final NumberFormat FLOATING_POINT_FORMAT = new DecimalFormat("0.#");
+    // Force floating point numbers to '.' format
+    private static final NumberFormat FLOATING_POINT_FORMAT = new DecimalFormat(
+            "0.#", DecimalFormatSymbols.getInstance(Locale.ENGLISH));
 
     public static boolean isValidInteger(String str) {
         try {
@@ -40,12 +45,7 @@ public class StringUtils {
     }
 
     public static boolean isValidFloat(String str) {
-        try {
-            Float.parseFloat(str);
-            return true;
-        } catch (NumberFormatException e) {
-            return false;
-        }
+        return parseFloat(str) != null;
     }
 
     public static Integer parseInt(String str) {
@@ -66,18 +66,16 @@ public class StringUtils {
 
     public static Float parseFloat(String str) {
         try {
-            return Float.parseFloat(str);
-        } catch (NumberFormatException e) {
+            final Number number = FLOATING_POINT_FORMAT.parse(str);
+            return number != null ? number.floatValue() : null;
+        } catch (NumberFormatException | ParseException e) {
             return null;
         }
     }
 
     public static float parseFloat(String str, float defaultValue) {
-        try {
-            return Float.parseFloat(str);
-        } catch (NumberFormatException e) {
-            return defaultValue;
-        }
+        final Float number = parseFloat(str);
+        return number != null ? number : defaultValue;
     }
 
     public static int length(String str) {

--- a/Project/Assets/Editor/Tests/StringUtilsTest.cs
+++ b/Project/Assets/Editor/Tests/StringUtilsTest.cs
@@ -31,6 +31,55 @@ using LunarConsolePluginInternal;
 
 public class StringUtilsTest
 {
+    #region Parsing
+
+    [Test]
+    public void TestParseFloat()
+    {
+        Assert.AreEqual(123f, StringUtils.ParseFloat("123"));
+        Assert.AreEqual(-123f, StringUtils.ParseFloat("-123"));
+        Assert.AreEqual(0f, StringUtils.ParseFloat("0", float.NaN));
+        Assert.AreEqual(3.14f, StringUtils.ParseFloat("3.14"));
+        Assert.AreEqual(-3.14f, StringUtils.ParseFloat("-3.14"));
+        Assert.AreEqual(float.NaN, StringUtils.ParseFloat("3.14f", float.NaN));
+        Assert.AreEqual(float.NaN, StringUtils.ParseFloat("abs", float.NaN));
+
+        float actual;
+        Assert.IsTrue(StringUtils.ParseFloat("123", out actual));
+        Assert.AreEqual(123f, actual);
+
+        Assert.IsTrue(StringUtils.ParseFloat("-123", out actual));
+        Assert.AreEqual(-123f, actual);
+
+        Assert.IsTrue(StringUtils.ParseFloat("0", out actual));
+        Assert.AreEqual(0f, actual);
+
+        Assert.IsTrue(StringUtils.ParseFloat("3.14", out actual));
+        Assert.AreEqual(3.14f, actual);
+
+        Assert.IsTrue(StringUtils.ParseFloat("-3.14", out actual));
+        Assert.AreEqual(-3.14f, actual);
+
+        Assert.IsFalse(StringUtils.ParseFloat("-3.14f", out _));
+        Assert.IsFalse(StringUtils.ParseFloat("abs", out _));
+    }
+
+    #endregion
+
+    #region String Representation
+
+    [Test]
+    public void TestFloatString()
+    {
+        Assert.AreEqual("3.14", StringUtils.ToString(3.14f));
+        Assert.AreEqual("-3.14", StringUtils.ToString(-3.14f));
+        Assert.AreEqual("0", StringUtils.ToString(0.0f));
+        Assert.AreEqual("123", StringUtils.ToString(123.0f));
+        Assert.AreEqual("-123", StringUtils.ToString(-123.0f));
+    }
+
+    #endregion
+
     #region Serialization
 
     [Test]

--- a/Project/Assets/LunarConsole/Scripts/LunarConsole.cs
+++ b/Project/Assets/LunarConsole/Scripts/LunarConsole.cs
@@ -548,7 +548,7 @@ namespace LunarConsolePlugin
                                     continue;
                                 }
 
-                                cvar.Value = value;
+                                cvar.Value = FixLegacyValue(cvar.Type, value);
                                 m_platform.OnVariableUpdated(m_registry, cvar);
                             }
                         }
@@ -606,6 +606,17 @@ namespace LunarConsolePlugin
         bool ShouldSaveVar(CVar cvar)
         {
             return !cvar.IsDefault && !cvar.HasFlag(CFlags.NoArchive);
+        }
+
+        private static string FixLegacyValue(CVarType type, string value)
+        {
+            // we need to fix incorrect value: https://github.com/SpaceMadness/lunar-unity-console/issues/201
+            if (type == CVarType.Float)
+            {
+                return value.Replace(',', '.');
+            }
+
+            return value;
         }
 
         #endregion
@@ -1253,7 +1264,7 @@ namespace LunarConsolePlugin
                     case CVarType.Float:
                     {
                         float floatValue;
-                        if (float.TryParse(value, out floatValue))
+                        if (StringUtils.ParseFloat(value, out floatValue))
                         {
                             variable.FloatValue = floatValue;
                             m_variablesDirty = true;

--- a/Project/Assets/LunarConsole/Scripts/Utils/StringUtils.cs
+++ b/Project/Assets/LunarConsole/Scripts/Utils/StringUtils.cs
@@ -23,6 +23,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Text;
 using System.Text.RegularExpressions;
 
@@ -32,6 +33,7 @@ namespace LunarConsolePluginInternal
 {
     public static class StringUtils
     {
+        private const NumberStyles FLOAT_NUMBER_STYLES = NumberStyles.Integer | NumberStyles.Float | NumberStyles.AllowDecimalPoint;
         private static readonly char[] kSpaceSplitChars = { ' ' };
 
         internal static string TryFormat(string format, params object[] args)
@@ -116,34 +118,19 @@ namespace LunarConsolePluginInternal
             return 0;
         }
 
-        public static float ParseFloat(string str)
+        public static float ParseFloat(string str, float defValue = 0.0f)
         {
-            return ParseFloat(str, 0.0f);
-        }
-
-        public static float ParseFloat(string str, float defValue)
-        {
-            if (!string.IsNullOrEmpty(str))
+            if (ParseFloat(str, out float result))
             {
-                float value;
-                bool succeed = float.TryParse(str, out value);
-                return succeed ? value : defValue;
+                return result;
             }
-
             return defValue;
         }
 
-        public static float ParseFloat(string str, out bool succeed)
+        public static bool ParseFloat(string str, out float result)
         {
-            if (!string.IsNullOrEmpty(str))
-            {
-                float value;
-                succeed = float.TryParse(str, out value);
-                return succeed ? value : 0.0f;
-            }
-
-            succeed = false;
-            return 0.0f;
+            // Force '.' as decimal point
+            return float.TryParse(str, FLOAT_NUMBER_STYLES, CultureInfo.InvariantCulture, out result);
         }
 
         public static bool ParseBool(string str)
@@ -543,79 +530,80 @@ namespace LunarConsolePluginInternal
 
         #region string representation
 
-        internal static string ToString(object value)
+        public static string ToString(object value)
         {
             return value != null ? value.ToString() : null;
         }
-        
-        internal static string ToString(int value)
+
+        public static string ToString(int value)
         {
             return value.ToString();
         }
 
-        internal static string ToString(float value)
+        public static string ToString(float value)
         {
-            return value.ToString("G");
+            // For '.' as decimal point
+            return value.ToString("G", CultureInfo.InvariantCulture);
         }
 
-        internal static string ToString(bool value)
+        public static string ToString(bool value)
         {
             return value.ToString();
         }
 
-        internal static string ToString(ref Color value)
+        public static string ToString(ref Color value)
         {
             if (value.a > 0.0f)
             {
                 return string.Format("{0} {1} {2} {3}", 
-                    value.r.ToString("G"), 
-                    value.g.ToString("G"), 
-                    value.b.ToString("G"), 
-                    value.a.ToString("G")
+                    ToString(value.r),
+                    ToString(value.g),
+                    ToString(value.b),
+                    ToString(value.a)
                 );
             }
 
-            return string.Format("{0} {1} {2}", 
-                value.r.ToString("G"), 
-                value.g.ToString("G"), 
-                value.b.ToString("G")
+            return string.Format("{0} {1} {2}",
+                ToString(value.r),
+                ToString(value.g),
+                ToString(value.b)
             );
         }
 
-        internal static string ToString(ref Rect value)
+        public static string ToString(ref Rect value)
         {
             return string.Format("{0} {1} {2} {3}", 
-                value.x.ToString("G"), 
-                value.y.ToString("G"), 
-                value.width.ToString("G"), 
-                value.height.ToString("G")
+                ToString(value.x), 
+                ToString(value.y), 
+                ToString(value.width), 
+                ToString(value.height)
             );
         }
 
-        internal static string ToString(ref Vector2 value)
+        public static string ToString(ref Vector2 value)
         {
             return string.Format("{0} {1}", 
-                value.x.ToString("G"), 
-                value.y.ToString("G")
+                ToString(value.x), 
+                ToString(value.y)
             );
         }
 
-        internal static string ToString(ref Vector3 value)
+        public static string ToString(ref Vector3 value)
         {
             return string.Format("{0} {1} {2}", 
-                value.x.ToString("G"), 
-                value.y.ToString("G"), 
-                value.z.ToString("G")
+                ToString(value.x), 
+                ToString(value.y), 
+                ToString(value.z)
             );
         }
 
-        internal static string ToString(ref Vector4 value)
+        public static string ToString(ref Vector4 value)
         {
             return string.Format("{0} {1} {2} {3}", 
-                value.x.ToString("G"), 
-                value.y.ToString("G"), 
-                value.z.ToString("G"), 
-                value.w.ToString("G")
+                ToString(value.x), 
+                ToString(value.y), 
+                ToString(value.z), 
+                ToString(value.w)
             );
         }
 


### PR DESCRIPTION
Float variables won't work correctly on locales that use `,` as a decimal point. Forcing everything to `.`.